### PR TITLE
don't show 'null' byline on some pages

### DIFF
--- a/reader.js
+++ b/reader.js
@@ -8,9 +8,7 @@ const { title, content, byline } = article
 const finalContent = `
 <h1>${title}</h1>
 
-<p>
-${byline}
-</p>
+${byline ? `<p>${byline}</p>` : ''}
 
 <hr>
 


### PR DESCRIPTION
right now the reader mode shows a null byline on some pages (like the homepage)
this fixes that