### PR TITLE
renderer for did

### DIFF
--- a/json.js
+++ b/json.js
@@ -8,7 +8,7 @@ const URL_REGEX = /(^\w+:|\.\/|\.\.\/|\/)[^\s<>"]+$/
 // Might only work on Chromium
 const text = document.querySelector('pre').innerText
 const parsed = JSON.parse(text)
-const rendered = render(parsed)
+const rendered = isDIDDocument(parsed) ? renderDIDDocument(parsed) : render(parsed)
 const title = location.href
 
 const content = `
@@ -28,6 +28,11 @@ const content = `
   }
   dl {
     margin: 0px;
+  }
+
+  details pre {
+    overflow-x: auto;
+    background: var(--browser-theme-background);
   }
 </style>
 ${rendered}
@@ -88,4 +93,93 @@ function makeLink (url, suffix, value = url) {
 
 function makeIPLDLink (cid) {
   return `ipld://${cid}/`
+}
+
+/**
+ * Detect if JSON is a DID Document
+ * Checks for common DID Document properties
+ */
+function isDIDDocument (json) {
+  if (typeof json !== 'object' || json === null) return false
+  
+  const hasDidId = typeof json.id === 'string' && json.id.startsWith('did:')
+
+  const hasDidFields = json['@context'] || json.verificationMethod || json.service || json.alsoKnownAs
+  
+  return hasDidId && hasDidFields
+}
+
+/**
+ * Render a DID Document with special formatting
+ */
+function renderDIDDocument (doc) {
+  const did = doc.id || 'Unknown DID'
+
+  // Extract handle from alsoKnownAs (AT Protocol format: at://handle)
+  const handle = (doc.alsoKnownAs || [])
+    .map((aka) => aka.replace('at://', '@'))
+    .find((aka) => aka.startsWith('@')) || did
+
+  // Extract PDS from service endpoints
+  const pds = (doc.service || [])
+    .filter((s) => s.type === 'AtprotoPersonalDataServer')
+    .map((s) => s.serviceEndpoint)
+    .join(', ') || null
+
+  const verificationKeys = (doc.verificationMethod || [])
+    .map((vm) => {
+      const keyValue = vm.publicKeyMultibase || vm.publicKeyBase64 || 'N/A'
+      return `<dt>${escapeHtml(vm.id || vm.type || '')}</dt>
+        <dd>
+          <dl>
+            <dt>Type</dt><dd>${escapeHtml(vm.type || '')}</dd>
+            <dt>Key</dt><dd><samp>${escapeHtml(keyValue)}</samp></dd>
+          </dl>
+        </dd>`
+    }).join('')
+
+  const services = (doc.service || [])
+    .map((s) => `<dt>${escapeHtml(s.id || '')}</dt>
+      <dd>
+        <dl>
+          <dt>Type</dt><dd>${escapeHtml(s.type || '')}</dd>
+          <dt>Endpoint</dt><dd><a href="${escapeHtml(s.serviceEndpoint || '')}">${escapeHtml(s.serviceEndpoint || '')}</a></dd>
+        </dl>
+      </dd>`).join('')
+
+  // Render aliases/alsoKnownAs
+  const aliases = (doc.alsoKnownAs || [])
+    .map((aka) => `<li><a href="${escapeHtml(aka)}">${escapeHtml(aka)}</a></li>`)
+    .join('')
+
+  // Render raw JSON for reference
+  const prettyJSON = JSON.stringify(doc, null, 2)
+
+  return `
+    <h1>${escapeHtml(handle)}</h1>
+    <dl>
+      <dt>DID</dt><dd><samp>${escapeHtml(did)}</samp></dd>
+      ${pds ? `<dt>PDS</dt><dd><a href="${escapeHtml(pds)}">${escapeHtml(pds)}</a></dd>` : ''}
+    </dl>
+
+    ${aliases ? `<section>
+      <h2>Also Known As</h2>
+      <ul>${aliases}</ul>
+    </section>` : ''}
+
+    ${verificationKeys ? `<section>
+      <h2>Verification Methods</h2>
+      <dl>${verificationKeys}</dl>
+    </section>` : ''}
+
+    ${services ? `<section>
+      <h2>Services</h2>
+      <dl>${services}</dl>
+    </section>` : ''}
+
+    <details>
+      <summary>Raw DID Document (JSON)</summary>
+      <pre><code>${escapeHtml(prettyJSON)}</code></pre>
+    </details>
+  `
 }


### PR DESCRIPTION

**Summary**
Added DID Document rendering support to the JSON renderer extension. When viewing DID documents (did:plc and did:web), the extension now detects them and renders a styled UI showing the user's handle, PDS server, verification keys, services, and a collapsible raw JSON section.

**Changes Made**
- Added `isDIDDocument()` function to detect DID documents by checking for `id` field starting with 'did:' and DID-specific properties
- Added `renderDIDDocument()` function to render styled DID document UI with handle, PDS, verification methods, and services
- Modified main rendering logic to use DID-specific rendering when a DID document is detected
- Added CSS styles for DID document sections and components

**Testing**
- Verified DID documents display styled UI instead of raw JSON
- Confirmed raw JSON section is collapsible
- Tested with various DID documents to ensure proper detection and rendering

This change enables native DID document viewing in Agregore browser with proper formatting and user-friendly presentation.


Related : https://github.com/AgregoreWeb/agregore-browser/pull/321 https://github.com/AgregoreWeb/agregore-browser/issues/301